### PR TITLE
Rename ByteBuffer.B to ByteBuffer.buf

### DIFF
--- a/bytebuffer.go
+++ b/bytebuffer.go
@@ -13,19 +13,28 @@ type ByteBuffer struct {
 
 	// B is a byte buffer to use in append-like workloads.
 	// See example code for details.
-	B []byte
+	buf []byte
 }
+
+// NewByteBuffer creates and initializes a new ByteBuffer using buf as its initial
+// contents.
+func NewByteBuffer(buf []byte) *ByteBuffer { return &ByteBuffer{buf: buf} }
 
 // Len returns the size of the byte buffer.
 func (b *ByteBuffer) Len() int {
-	return len(b.B)
+	return len(b.buf)
+}
+
+// Cap returns the capacity of the buffer's underlying byte slice.
+func (b *ByteBuffer) Cap() int {
+	return cap(b.buf)
 }
 
 // ReadFrom implements io.ReaderFrom.
 //
 // The function appends all the data read from r to b.
 func (b *ByteBuffer) ReadFrom(r io.Reader) (int64, error) {
-	p := b.B
+	p := b.buf
 	nStart := int64(len(p))
 	nMax := int64(cap(p))
 	n := nStart
@@ -45,7 +54,7 @@ func (b *ByteBuffer) ReadFrom(r io.Reader) (int64, error) {
 		nn, err := r.Read(p[n:])
 		n += int64(nn)
 		if err != nil {
-			b.B = p[:n]
+			b.buf = p[:n]
 			n -= nStart
 			if err == io.EOF {
 				return n, nil
@@ -57,7 +66,7 @@ func (b *ByteBuffer) ReadFrom(r io.Reader) (int64, error) {
 
 // WriteTo implements io.WriterTo.
 func (b *ByteBuffer) WriteTo(w io.Writer) (int64, error) {
-	n, err := w.Write(b.B)
+	n, err := w.Write(b.buf)
 	return int64(n), err
 }
 
@@ -65,12 +74,12 @@ func (b *ByteBuffer) WriteTo(w io.Writer) (int64, error) {
 //
 // The purpose of this function is bytes.Buffer compatibility.
 func (b *ByteBuffer) Bytes() []byte {
-	return b.B
+	return b.buf
 }
 
 // Write implements io.Writer - it appends p to ByteBuffer.B
 func (b *ByteBuffer) Write(p []byte) (int, error) {
-	b.B = append(b.B, p...)
+	b.buf = append(b.buf, p...)
 	return len(p), nil
 }
 
@@ -80,32 +89,32 @@ func (b *ByteBuffer) Write(p []byte) (int, error) {
 //
 // The function always returns nil.
 func (b *ByteBuffer) WriteByte(c byte) error {
-	b.B = append(b.B, c)
+	b.buf = append(b.buf, c)
 	return nil
 }
 
 // WriteString appends s to ByteBuffer.B.
 func (b *ByteBuffer) WriteString(s string) (int, error) {
-	b.B = append(b.B, s...)
+	b.buf = append(b.buf, s...)
 	return len(s), nil
 }
 
 // Set sets ByteBuffer.B to p.
 func (b *ByteBuffer) Set(p []byte) {
-	b.B = append(b.B[:0], p...)
+	b.buf = append(b.buf[:0], p...)
 }
 
 // SetString sets ByteBuffer.B to s.
 func (b *ByteBuffer) SetString(s string) {
-	b.B = append(b.B[:0], s...)
+	b.buf = append(b.buf[:0], s...)
 }
 
 // String returns string representation of ByteBuffer.B.
 func (b *ByteBuffer) String() string {
-	return string(b.B)
+	return string(b.buf)
 }
 
 // Reset makes ByteBuffer.B empty.
 func (b *ByteBuffer) Reset() {
-	b.B = b.B[:0]
+	b.buf = b.buf[:0]
 }

--- a/bytebuffer_example_test.go
+++ b/bytebuffer_example_test.go
@@ -11,9 +11,8 @@ func ExampleByteBuffer() {
 
 	bb.WriteString("first line\n")
 	bb.Write([]byte("second line\n"))
-	bb.B = append(bb.B, "third line\n"...)
 
-	fmt.Printf("bytebuffer contents=%q", bb.B)
+	fmt.Printf("bytebuffer contents=%q", bb.Bytes())
 
 	// It is safe to release byte buffer now, since it is
 	// no longer used.

--- a/bytebuffer_test.go
+++ b/bytebuffer_test.go
@@ -34,9 +34,10 @@ func TestByteBufferReadFrom(t *testing.T) {
 		}
 		for j := 0; j < i; j++ {
 			start := prefixLen + int64(j)*expectedN
-			b := bb.B[start : start+expectedN]
-			if string(b) != expectedS {
-				t.Fatalf("unexpected byteBuffer contents: %q. Expecting %q", b, expectedS)
+			got := bb.Bytes()
+			got = got[start : start+expectedN]
+			if string(got) != expectedS {
+				t.Fatalf("unexpected byteBuffer contents: %q. Expecting %q", got, expectedS)
 			}
 		}
 	}
@@ -93,10 +94,10 @@ func testByteBufferGetPut(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		expectedS := fmt.Sprintf("num %d", i)
 		b := Get()
-		b.B = append(b.B, "num "...)
-		b.B = append(b.B, fmt.Sprintf("%d", i)...)
-		if string(b.B) != expectedS {
-			t.Fatalf("unexpected result: %q. Expecting %q", b.B, expectedS)
+		b.WriteString("num ")
+		b.WriteString(fmt.Sprintf("%d", i))
+		if b.String() != expectedS {
+			t.Fatalf("unexpected result: %q. Expecting %q", b.Bytes(), expectedS)
 		}
 		Put(b)
 	}
@@ -108,7 +109,7 @@ func testByteBufferGetString(t *testing.T) {
 		b := Get()
 		b.SetString(expectedS)
 		if b.String() != expectedS {
-			t.Fatalf("unexpected result: %q. Expecting %q", b.B, expectedS)
+			t.Fatalf("unexpected result: %q. Expecting %q", b.Bytes(), expectedS)
 		}
 		Put(b)
 	}

--- a/pool.go
+++ b/pool.go
@@ -50,9 +50,7 @@ func (p *Pool) Get() *ByteBuffer {
 	if v != nil {
 		return v.(*ByteBuffer)
 	}
-	return &ByteBuffer{
-		B: make([]byte, 0, atomic.LoadUint64(&p.defaultSize)),
-	}
+	return NewByteBuffer(make([]byte, 0, atomic.LoadUint64(&p.defaultSize)))
 }
 
 // Put returns byte buffer to the pool.
@@ -65,14 +63,14 @@ func Put(b *ByteBuffer) { defaultPool.Put(b) }
 //
 // The buffer mustn't be accessed after returning to the pool.
 func (p *Pool) Put(b *ByteBuffer) {
-	idx := index(len(b.B))
+	idx := index(b.Len())
 
 	if atomic.AddUint64(&p.calls[idx], 1) > calibrateCallsThreshold {
 		p.calibrate()
 	}
 
 	maxSize := int(atomic.LoadUint64(&p.maxSize))
-	if maxSize == 0 || cap(b.B) <= maxSize {
+	if maxSize == 0 || b.Cap() <= maxSize {
 		b.Reset()
 		p.pool.Put(b)
 	}

--- a/pool_test.go
+++ b/pool_test.go
@@ -78,10 +78,10 @@ func testPoolVariousSizes(t *testing.T) {
 
 func testGetPut(t *testing.T, n int) {
 	bb := Get()
-	if len(bb.B) > 0 {
+	if bb.Len() > 0 {
 		t.Fatalf("non-empty byte buffer returned from acquire")
 	}
-	bb.B = allocNBytes(bb.B, n)
+	bb = NewByteBuffer(allocNBytes(bb.Bytes(), n))
 	Put(bb)
 }
 


### PR DESCRIPTION
I think, it's better to use private underlying bytes slice
