### PR TITLE
improve defaultSize adjustment for rare case when next few j > 0 p.calls after sort

### DIFF
--- a/pool_test.go
+++ b/pool_test.go
@@ -1,6 +1,7 @@
 package bytebufferpool
 
 import (
+	"math/bits"
 	"math/rand"
 	"testing"
 	"time"
@@ -40,6 +41,43 @@ func TestPoolCalibrate(t *testing.T) {
 	}
 }
 
+func TestPoolCalibrateWithAdjustment(t *testing.T) {
+
+	var p Pool
+
+	const n = 510
+
+	adjN := n << 2
+
+	// smaller buffer
+	allocNBytesMtimes(&p, n, calibrateCallsThreshold-10)
+
+	// t.Log(p.calls)
+
+	// never trigger calibrate, never used as adjustment for defaultSize
+	for i, s := 0, adjN<<4; i < calibrateCallsThreshold>>1; i++ {
+		v := s + rand.Intn(maxSize)
+		allocNBytesInP(&p, v)
+	}
+
+	// larger buffer
+	allocNBytesMtimes(&p, adjN, calibrateCallsThreshold-10)
+
+	// t.Log(p.calls)
+
+	// now throw away existing larger buf from pool
+	_ = p.Get()
+
+	// ... and now finish with new smaller buf (emulate a long process that uses it)
+	allocNBytesMtimes(&p, n, 11)
+
+	// t.Logf("%#v", p)
+
+	if v := powOfTwo64(uint64(adjN)); v != p.defaultSize {
+		t.Fatalf("wrong pool final defaultSize: want %d, got %d", v, p.defaultSize)
+	}
+}
+
 func TestPoolVariousSizesSerial(t *testing.T) {
 	testPoolVariousSizes(t)
 }
@@ -59,6 +97,18 @@ func TestPoolVariousSizesConcurrent(t *testing.T) {
 		case <-time.After(3 * time.Second):
 			t.Fatalf("timeout")
 		}
+	}
+}
+
+//go:noinline
+func TestIntArithmetic(t *testing.T) {
+
+	if float64(maxPercentileNumer) != (float64(maxPercentile) * float64(maxPercentileDenom)) {
+		t.Fatalf("wrong maxPercentile interpolation: want %f, got %f", maxPercentile, float64(maxPercentileNumer)/float64(maxPercentileDenom))
+	}
+
+	if float64(calibrateDefaultSizeAdjustmentsFactorNumer) != (float64(calibrateDefaultSizeAdjustmentsFactor) * float64(calibrateDefaultSizeAdjustmentsFactorDenom)) {
+		t.Fatalf("wrong maxPercentile interpolation: want %f, got %f", calibrateDefaultSizeAdjustmentsFactor, float64(calibrateDefaultSizeAdjustmentsFactorNumer)/float64(calibrateDefaultSizeAdjustmentsFactorDenom))
 	}
 }
 
@@ -90,5 +140,46 @@ func allocNBytes(dst []byte, n int) []byte {
 	if diff <= 0 {
 		return dst[:n]
 	}
-	return append(dst, make([]byte, diff)...)
+	// must return buffer with len == requested size n, not `n - cap(dst)`
+	return append(dst[:cap(dst)], make([]byte, diff)...)
+}
+
+func allocNBytesInP(p *Pool, n int) {
+	b := p.Get()
+	b.B = allocNBytes(b.B, n)
+	p.Put(b)
+}
+
+func allocNBytesMtimes(p *Pool, n, limit int) {
+	for i := 0; i < limit; i++ {
+		allocNBytesInP(p, n)
+	}
+}
+
+// 2^z >= n with min(z)
+func powOfTwo64(n uint64) uint64 {
+	// ((n - 1) & n) - remove the leftmost one bit, 2^k ==> 0, 0 ==> 0, others > 0
+	// ((n - 1) & n) >> 1 - place for sign to avoid overflow, 2^k ==> 0, 0 ==> 0, others > 0
+	// ^(((n - 1) & n) >> 1) - invert result, 2^k ==> uint64(-1), 0 ==> uint64(-1), others < -1
+	// (^(((n - 1) & n) >> 1) + 1) - for 2^k ==> 0, 0 ==> 0, others < 0
+	// uint(^(((n - 1) & n) >> 1) + 1 - z) >> 63 - got sign of result as leftmost bit, 2^k -> 0, 0 -> 0, others -> 1
+	a := int(uint64(^(((n-1)&n)>>1)+1) >> 63)
+	z := int(((n - 1) &^ n) >> 63) // 0 -> 1, others -> 0
+	return 1 << uint(bits.Len64(n)-1+z+a)
+}
+
+func allocNMBytesInP(p *Pool, n, m int) {
+	// ATN! preserve order, its important
+	bn := p.Get()
+	bm := p.Get()
+	bn.B = allocNBytes(bn.B, n)
+	bm.B = allocNBytes(bm.B, m)
+	p.Put(bn)
+	p.Put(bm)
+}
+
+func allocNMBytesXtimes(p *Pool, n, m int, limit int) {
+	for i := 0; i < limit; i++ {
+		allocNMBytesInP(p, n, m)
+	}
 }


### PR DESCRIPTION
improve defaultSize adjustment for rare case when next few j > 0 p.calls after sort (==> a) have a[j].calls ~= a[0].calls and some of them a[j].size > defaultSize (== a[0].size) + added test TestPoolCalibrateWithAdjustment

For example, if we have after sort.Sort(a):
https://github.com/valyala/bytebufferpool/blob/9ccb276166ca44142323af78b12322a5bc714928/pool.go#L118

- `a[0].calls = 42001, a[0].size = 512`
- `a[1].calls = 40000, a[0].size = 1024`

Before this commit we use `512` as new `p.defaultSize` and in this commit we use `1024` as new `p.defaultSize`, what may prevent very rare case, when in 40000 new allocations out of 82000 we have additional memory allocation for b.B by `append` after initial allocation by `pool.New` in price of additional allocated memory for all another allocations, include top `512` sizes

_Nearness_ of the a[j].calls to the initial a[0].calls is adjusted by the `calibrateDefaultSizeAdjustmentsSpread` and `calibrateDSASGcd` constants

+ also replaced floating-point arithmetic with integer muldiv equivalent (calibrate() should become slightly faster)
+ fix tests fn allocNBytes()
+ some microoptimizations

Sorry for my bad English