### PR TITLE
Reduce Memory Usage by Optimizing Order of Fields

### DIFF
--- a/bytebuffer.go
+++ b/bytebuffer.go
@@ -10,7 +10,6 @@ import "io"
 //
 // Use Get for obtaining an empty byte buffer.
 type ByteBuffer struct {
-
 	// B is a byte buffer to use in append-like workloads.
 	// See example code for details.
 	B []byte

--- a/pool.go
+++ b/pool.go
@@ -23,13 +23,12 @@ const (
 // Properly determined byte buffer types with their own pools may help reducing
 // memory waste.
 type Pool struct {
+	pool        sync.Pool
 	calls       [steps]uint64
 	calibrating uint64
 
 	defaultSize uint64
 	maxSize     uint64
-
-	pool sync.Pool
 }
 
 var defaultPool Pool


### PR DESCRIPTION
Results:

```console
ubuntu@ubuntu:~/Desktop/git/bytebufferpool$ betteralign -test_files -generated_files -apply ./...
/home/ubuntu/Desktop/git/bytebufferpool/pool.go:25:11: 184 bytes saved: struct with 224 pointer bytes could be 40
```

@erikdubbelboer @valyala I'm not sure who is the maintainer of this repo.